### PR TITLE
add syntax highlighting

### DIFF
--- a/app/javascript/controllers/highlight_controller.js
+++ b/app/javascript/controllers/highlight_controller.js
@@ -1,0 +1,21 @@
+import { Controller } from "@hotwired/stimulus"
+import hljs from 'highlight.js';
+
+export default class extends Controller {
+  static values = { categories: Array }
+
+  connect() {
+    const code = this.element.querySelector('code');
+    const language = this.findLanguage();
+
+    if (language) { code.classList.add(`language-${language}`) };
+    hljs.highlightElement(code);
+  }
+
+  findLanguage() {
+    for (const category of this.categoriesValue) {
+      if (hljs.listLanguages().includes(category)) { return category; }
+    }
+    return null;
+  }
+}

--- a/app/views/components/blueprint_view.rb
+++ b/app/views/components/blueprint_view.rb
@@ -47,7 +47,11 @@ class BlueprintView < Phlex::HTML
         end
 
         div(class: "mt-4 space-y-6 text-sm text-gray-800") do
-          p(class: "whitespace-pre-wrap") { @blueprint.code }
+          pre(class: "whitespace-pre-wrap", data: { controller: 'highlight', "highlight-categories-value": @blueprint.categories.pluck(:title).to_json }) do
+            code do
+              @blueprint.code
+            end
+          end
         end
       end
     end

--- a/app/views/layouts/application_layout.rb
+++ b/app/views/layouts/application_layout.rb
@@ -12,8 +12,10 @@ class ApplicationLayout < ApplicationView
         meta name: "viewport", content: "width=device-width,initial-scale=1"
         csp_meta_tag
         csrf_meta_tags
+        stylesheet_link_tag "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.3.1/styles/default.min.css", media: "all", "data-turbo-track": "reload"
         stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload"
         stylesheet_link_tag "application", data_turbo_track: "reload"
+
         javascript_importmap_tags
       end
 

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -5,3 +5,4 @@ pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true
 pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
 pin_all_from "app/javascript/controllers", under: "controllers"
+pin "highlight.js", to: "https://ga.jspm.io/npm:highlight.js@11.9.0/es/index.js"


### PR DESCRIPTION
use hightlight.js!

use our llm generated categories to find the appropriate language to use for highlighting. 
without a language the library defaults to trying to find a best fit (it's not very good) 
but just in case we don't have any languages in our category it will still work! 

potential issues later: 
if categories call out multiple languages we may run into issues here. (this has not locally with the limited number of tests I've tried though)