### PR TITLE
update the unicode version to build properly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,4 +41,3 @@ end
 gem "langchainrb_rails"
 gem "neighbor"
 gem "ruby-openai"
-gem "unicode"

--- a/Gemfile
+++ b/Gemfile
@@ -41,4 +41,4 @@ end
 gem "langchainrb_rails"
 gem "neighbor"
 gem "ruby-openai"
-gem "unicode", "~> 0.4.4.5"
+gem "unicode"

--- a/Gemfile
+++ b/Gemfile
@@ -41,3 +41,4 @@ end
 gem "langchainrb_rails"
 gem "neighbor"
 gem "ruby-openai"
+gem "unicode", "~> 0.4.4.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -335,7 +335,7 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    unicode (0.4.4.4)
+    unicode (0.4.4.5)
     uri (0.13.0)
     vcr (6.2.0)
     web-console (4.2.1)


### PR DESCRIPTION
I had difficulty building this gem. [This commit](https://github.com/blackwinter/unicode/commit/66d6fd211a64db3e1ec21ae17cde2d42172a2aaa) which is included in the 0.4.4.5 version fixed it for me. I assume other people will have the same issue so I would like to bump the version.